### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,45 +4,45 @@
 # Class
 #######################################
 
-Ch376msc KEYWORD1
+Ch376msc	KEYWORD1
 
 #######################################
 # Methods and Functions 
 #######################################	
 
-init			KEYWORD2
-mount			KEYWORD2
-dirInfoSave     KEYWORD2
-openFile		KEYWORD2
-closeFile		KEYWORD2
-moveCursor		KEYWORD2
-deleteFile		KEYWORD2
-pingDevice		KEYWORD2
-listDir			KEYWORD2
-readFile		KEYWORD2
-writeFile		KEYWORD2
-checkDrive      KEYWORD2
+init	KEYWORD2
+mount	KEYWORD2
+dirInfoSave	KEYWORD2
+openFile	KEYWORD2
+closeFile	KEYWORD2
+moveCursor	KEYWORD2
+deleteFile	KEYWORD2
+pingDevice	KEYWORD2
+listDir	KEYWORD2
+readFile	KEYWORD2
+writeFile	KEYWORD2
+checkDrive	KEYWORD2
 
-getFileSize		KEYWORD2
-getYear         KEYWORD2
-getMonth        KEYWORD2
-getDay          KEYWORD2
-getHour         KEYWORD2
-getMinute       KEYWORD2
-getSecond       KEYWORD2
-getStatus		KEYWORD2
-getFileName		KEYWORD2
+getFileSize	KEYWORD2
+getYear	KEYWORD2
+getMonth	KEYWORD2
+getDay	KEYWORD2
+getHour	KEYWORD2
+getMinute	KEYWORD2
+getSecond	KEYWORD2
+getStatus	KEYWORD2
+getFileName	KEYWORD2
 getFileSizeStr	KEYWORD2
-getDeviceStatus KEYWORD2
+getDeviceStatus	KEYWORD2
 getCHpresence	KEYWORD2
 
-setFileName		KEYWORD2
-setYear         KEYWORD2
-setMonth        KEYWORD2
-setDay          KEYWORD2
-setHour         KEYWORD2
-setMinute       KEYWORD2
-setSecond       KEYWORD2
+setFileName	KEYWORD2
+setYear	KEYWORD2
+setMonth	KEYWORD2
+setDay	KEYWORD2
+setHour	KEYWORD2
+setMinute	KEYWORD2
+setSecond	KEYWORD2
 
 #######################################
 # Constants


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords